### PR TITLE
MCP Trust Score

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ESP RainMaker MCP Server
+[![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/espressif/esp-rainmaker-mcp)](https://archestra.ai/mcp-catalog/espressif__esp-rainmaker-mcp)
 
 This project provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server wrapper around the [`esp-rainmaker-cli`](https://github.com/espressif/esp-rainmaker-cli) Python library.
 It allows MCP-compatible clients (like LLMs or applications such as Cursor, Claude Desktop, and Windsurf) to interact with your [ESP RainMaker](https://rainmaker.espressif.com/) devices using the official CLI.


### PR DESCRIPTION
Hi!

This PR adds the "Trust Score" badge from our new Open Source MCP catalog.

Our catalog evaluates MCP servers based on technical quality—like protocol feature implementation and dependency health—rather than vanity metrics like GitHub stars.

The scoring process is fully transparent and reproducible:
- Evaluation Script: https://github.com/archestra-ai/website/blob/main/app/app/mcp-catalog/scripts/evaluate-catalog.ts
- Your Server's Page: https://archestra.ai/mcp-catalog/espressif__esp-rainmaker-mcp

The badge is designed to be respectful to the structure of your readme, example: [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/topoteretes/cognee/cognee-mcp)](https://archestra.ai/mcp-catalog/topoteretes__cognee__cognee-mcp)

Projects like Grafana MCP (https://github.com/grafana/mcp-grafana) are already participating. 

We believe that transparent and truly open source MCP catalog should help the community to identify great MCP servers like yours 😊

We'd appreciate your support by merging this PR!